### PR TITLE
enforced mongoose Roster name is unique

### DIFF
--- a/backend/mongo/Roster.js
+++ b/backend/mongo/Roster.js
@@ -5,6 +5,7 @@ const taskSchema = require("./Task").schema;
 const rosterSchema = mongoose.Schema({
   title: {
     type: String,
+    unique: true,
   },
   tasks: {
     type: [taskSchema],


### PR DESCRIPTION
Changed a mongoose rule for the Roster title so it is enforced as unique. This disallows two rosters with the same name.

As Roster is a subdocument of Room, this enforces unique names within a room, not across all rooms.